### PR TITLE
Feature/one line installation 2.1 mac installation

### DIFF
--- a/install-scripts/mac/skm-install-mac.sh
+++ b/install-scripts/mac/skm-install-mac.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+GIT_SKM_REPO=https://github.com/splashkit/skm.git
+MARK_CHECK="\xE2\x9C\x94"
+MARK_CROSS="\xE2\x9C\x95"
+
+HOME_PATH=~
+INSTALL_PATH="${HOME_PATH}/.splashkit"
+
+function has_git() {
+	git --help 2>&1 > /dev/null
+	return $?
+}
+
+function install_git() {
+	echo "macOS developer tools are currently not installed which are required for installation skm."
+	read -p "Would you like to install them now? " -n 1 -r
+	echo ""
+	if [[ $REPLY =~ [Yy]$ ]]
+	then
+		xcode-select --install
+	else
+    	echo "macOS developer tools not installed, please run: \"xcode-select --install\" in the terminal and then reinstall."
+		exit 1
+	fi
+}
+
+echo "Checking for macOS developer tools..."
+has_git
+if [ $? -ne 0 ]; then
+	install_git
+	has_git
+	if [ $? -ne 0 ]; then
+		printf "\t$MARK_CROSS Failed to install macOS developer tools. Please ensure you have \"git\" installed and try again.\n"
+		exit 1
+	fi
+else
+	printf "\t$MARK_CHECK macOS developer tools appears to be installed\n"
+fi
+
+echo "Checking for an existing version of SplashKit..."
+if [ -d "${INSTALL_PATH}" ]; then
+	printf "\t$MARK_CROSS SplashKit is already installed!\n"
+	read -p "Would you like to completely re-install SplashKit? " -n 1 -r
+	echo ""
+	if [[ $REPLY =~ [Yy]$ ]]; then
+		D=`date +%y%m%d-%H%M%S`
+		OLD_PATH="$INSTALL_PATH-$D"
+		echo "Removing existing SplashKit installation..."
+		mv $INSTALL_PATH $OLD_PATH
+		if [ -d "${INSTALL_PATH}" ]; then
+			printf "\t$MARK_CROSS failed to remove existing SplashKit installation.\n"
+			exit 1
+		else
+			printf "\t$MARK_CHECK removed existing SplashKit installation.\n"
+		fi
+	else
+		printf "\t$MARK_CHECK SplashKit is already installed.\n"
+		exit 1
+	fi
+fi
+
+echo "Installing SplashKit..."
+git clone --depth 1 --branch master $GIT_SKM_REPO "${INSTALL_PATH}"
+if [ -d "${INSTALL_PATH}" ]; then
+	printf "\t$MARK_CHECK SplashKit was installed.\n"
+else
+	printf "\t$MARK_CROSS failed to install SplashKit.\n"
+	exit 1
+fi
+
+# Add to .bashrc if using bash and path line is missing for SplashKit inclusion.
+if [ ${SHELL} = "/bin/bash" ]; then
+	echo "Adding \"$INSTALL_PATH\" to your bash profile..."
+	grep -Fqx "export PATH=\"$INSTALL_PATH:\$PATH\"" ~/.bash_profile || echo "export PATH=\"$INSTALL_PATH:\$PATH\"" >> ~/.bash_profile
+    grep -Fqx "export PATH=\"$INSTALL_PATH:\$PATH\"" ~/.bashrc || echo "export PATH=\"$INSTALL_PATH:\$PATH\"" >> ~/.bashrc
+fi
+
+# Add to .zshrc if using zsh and path line is missing for SplashKit inclusion.
+if [ ${SHELL} = "/bin/zsh" ]; then
+	echo "Adding \"$INSTALL_PATH\" to your ZSH profile..."
+    grep -Fqx "export PATH=\"$INSTALL_PATH:\$PATH\"" ~/.zshrc || echo "export PATH=\"$INSTALL_PATH:\$PATH\"" >> ~/.zshrc
+fi
+
+printf "\t$MARK_CHECK done\n"
+export PATH="$INSTALL_PATH:$PATH"
+
+# Verify installation and access
+SKM_PATH="${INSTALL_PATH}/skm"
+if [ -f $SKM_PATH ]; then
+	printf "$MARK_CHECK SplashKit installed successfully!\n"
+else
+	printf "$MARK_CROSS SplashKit installation failed!\n"
+fi
+
+find "${INSTALL_PATH}" -name "*.sh" -exec chmod a+x "{}" \;
+
+which skm 2>&1 > /dev/null
+if [ $? -ne 0 ]; then
+	printf "$MARK_CROSS Failed to validate \"skm\" command.\n"
+	exit 1
+else
+	printf "$MARK_CHECK Verified that \"skm\" can be accessed.\n"
+fi
+
+read -p "Would you like to install the recommended developer tools for SplashKit?: " -n 1 -r
+echo ""
+if [[ $REPLY =~ [Yy]$ ]]
+then
+	if [ -d "/Applications/Visual Studio Code.app" ]; then
+		printf "\t$MARK_CHECK Microsoft Visual Studio Code is already installed\n"
+	else
+		echo "Installing Microsoft Visual Studio Code..."
+		mkdir -p /tmp/.skm-tmp/vscode
+		cd /tmp/.skm-tmp/vscode
+		rm *.zip
+		curl -LOJ "https://code.visualstudio.com/sha/download?build=stable&os=darwin-universal"
+		unzip *.zip
+		cp -R ./Visual\ Studio\ Code.app /Application
+		if [ -d "/Applications/Visual Studio Code.app" ]; then
+			printf "\t$MARK_CHECK Microsoft Visual Studio Code was installed\n"
+		else
+			printf "\t$MARK_CROSS Failed to install Microsoft Visual Studio Code\n"
+		fi
+	fi
+fi
+
+printf "$MARK_CHECK SplashKit installation process has been completed.\n"
+echo "Type \"skm help\" to get started."

--- a/install-scripts/mac/skm-install-mac.sh
+++ b/install-scripts/mac/skm-install-mac.sh
@@ -31,8 +31,7 @@ if has_git; then
     echo -e "\t$MARK_CHECK macOS developer tools appears to be installed"
 else
     install_developer_tools
-    has_git
-    if [ $? -ne 0 ]; then
+    if ! has_git; then
         echo -e "\t$MARK_CROSS Failed to install macOS developer tools. Please ensure you have \"git\" installed and try again."
         exit 1
     fi

--- a/install-scripts/mac/skm-install-mac.sh
+++ b/install-scripts/mac/skm-install-mac.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+
+set -eu
 GIT_SKM_REPO=https://github.com/splashkit/skm.git
 MARK_CHECK="\xE2\x9C\x94"
 MARK_CROSS="\xE2\x9C\x95"
@@ -11,36 +13,35 @@ function has_git() {
 	return $?
 }
 
-function install_git() {
+function install_developer_tools() {
 	echo "macOS developer tools are currently not installed which are required for installation skm."
-	read -p "Would you like to install them now? " -n 1 -r
+	read -p "Would you like to install them now? " -n 1 -r < /dev/tty
 	echo ""
 	if [[ $REPLY =~ [Yy]$ ]]
 	then
 		xcode-select --install
 	else
-    	echo "macOS developer tools not installed, please run: \"xcode-select --install\" in the terminal and then reinstall."
+		echo "macOS developer tools not installed, please run: \"xcode-select --install\" in the terminal and then reinstall."
 		exit 1
 	fi
 }
 
 echo "Checking for macOS developer tools..."
-has_git
-if [ $? -ne 0 ]; then
-	install_git
+if has_git; then
+	echo -e "\t$MARK_CHECK macOS developer tools appears to be installed"
+else
+	install_developer_tools
 	has_git
 	if [ $? -ne 0 ]; then
-		printf "\t$MARK_CROSS Failed to install macOS developer tools. Please ensure you have \"git\" installed and try again.\n"
+		echo -e "\t$MARK_CROSS Failed to install macOS developer tools. Please ensure you have \"git\" installed and try again."
 		exit 1
 	fi
-else
-	printf "\t$MARK_CHECK macOS developer tools appears to be installed\n"
 fi
 
 echo "Checking for an existing version of SplashKit..."
 if [ -d "${INSTALL_PATH}" ]; then
-	printf "\t$MARK_CROSS SplashKit is already installed!\n"
-	read -p "Would you like to completely re-install SplashKit? " -n 1 -r
+	echo -e "\t$MARK_CROSS SplashKit is already installed!"
+	read -p "Would you like to completely re-install SplashKit? " -n 1 -r < /dev/tty
 	echo ""
 	if [[ $REPLY =~ [Yy]$ ]]; then
 		D=`date +%y%m%d-%H%M%S`
@@ -48,13 +49,13 @@ if [ -d "${INSTALL_PATH}" ]; then
 		echo "Removing existing SplashKit installation..."
 		mv $INSTALL_PATH $OLD_PATH
 		if [ -d "${INSTALL_PATH}" ]; then
-			printf "\t$MARK_CROSS failed to remove existing SplashKit installation.\n"
+			echo -e "\t$MARK_CROSS failed to remove existing SplashKit installation."
 			exit 1
 		else
-			printf "\t$MARK_CHECK removed existing SplashKit installation.\n"
+			echo -e "\t$MARK_CHECK removed existing SplashKit installation."
 		fi
 	else
-		printf "\t$MARK_CHECK SplashKit is already installed.\n"
+		echo -e "\t$MARK_CHECK SplashKit is already installed."
 		exit 1
 	fi
 fi
@@ -62,9 +63,9 @@ fi
 echo "Installing SplashKit..."
 git clone --depth 1 --branch master $GIT_SKM_REPO "${INSTALL_PATH}"
 if [ -d "${INSTALL_PATH}" ]; then
-	printf "\t$MARK_CHECK SplashKit was installed.\n"
+	echo -e "\t$MARK_CHECK SplashKit was installed."
 else
-	printf "\t$MARK_CROSS failed to install SplashKit.\n"
+	echo -e "\t$MARK_CROSS failed to install SplashKit."
 	exit 1
 fi
 
@@ -72,57 +73,34 @@ fi
 if [ ${SHELL} = "/bin/bash" ]; then
 	echo "Adding \"$INSTALL_PATH\" to your bash profile..."
 	grep -Fqx "export PATH=\"$INSTALL_PATH:\$PATH\"" ~/.bash_profile || echo "export PATH=\"$INSTALL_PATH:\$PATH\"" >> ~/.bash_profile
-    grep -Fqx "export PATH=\"$INSTALL_PATH:\$PATH\"" ~/.bashrc || echo "export PATH=\"$INSTALL_PATH:\$PATH\"" >> ~/.bashrc
+	grep -Fqx "export PATH=\"$INSTALL_PATH:\$PATH\"" ~/.bashrc || echo "export PATH=\"$INSTALL_PATH:\$PATH\"" >> ~/.bashrc
 fi
 
 # Add to .zshrc if using zsh and path line is missing for SplashKit inclusion.
 if [ ${SHELL} = "/bin/zsh" ]; then
 	echo "Adding \"$INSTALL_PATH\" to your ZSH profile..."
-    grep -Fqx "export PATH=\"$INSTALL_PATH:\$PATH\"" ~/.zshrc || echo "export PATH=\"$INSTALL_PATH:\$PATH\"" >> ~/.zshrc
+	grep -Fqx "export PATH=\"$INSTALL_PATH:\$PATH\"" ~/.zshrc || echo "export PATH=\"$INSTALL_PATH:\$PATH\"" >> ~/.zshrc
 fi
 
-printf "\t$MARK_CHECK done\n"
+echo -e "\t$MARK_CHECK Done"
 export PATH="$INSTALL_PATH:$PATH"
 
 # Verify installation and access
 SKM_PATH="${INSTALL_PATH}/skm"
 if [ -f $SKM_PATH ]; then
-	printf "$MARK_CHECK SplashKit installed successfully!\n"
+	echo -e "$MARK_CHECK SplashKit installed successfully!"
 else
-	printf "$MARK_CROSS SplashKit installation failed!\n"
+	echo -e "$MARK_CROSS SplashKit installation failed!"
 fi
 
 find "${INSTALL_PATH}" -name "*.sh" -exec chmod a+x "{}" \;
 
-which skm 2>&1 > /dev/null
-if [ $? -ne 0 ]; then
-	printf "$MARK_CROSS Failed to validate \"skm\" command.\n"
-	exit 1
+if which skm > /dev/null 2>&1; then
+	echo -e "$MARK_CHECK Verified that \"skm\" can be accessed."
 else
-	printf "$MARK_CHECK Verified that \"skm\" can be accessed.\n"
+	echo -e "$MARK_CROSS Failed to validate \"skm\" command."
+	exit 1
 fi
 
-read -p "Would you like to install the recommended developer tools for SplashKit?: " -n 1 -r
-echo ""
-if [[ $REPLY =~ [Yy]$ ]]
-then
-	if [ -d "/Applications/Visual Studio Code.app" ]; then
-		printf "\t$MARK_CHECK Microsoft Visual Studio Code is already installed\n"
-	else
-		echo "Installing Microsoft Visual Studio Code..."
-		mkdir -p /tmp/.skm-tmp/vscode
-		cd /tmp/.skm-tmp/vscode
-		rm *.zip
-		curl -LOJ "https://code.visualstudio.com/sha/download?build=stable&os=darwin-universal"
-		unzip *.zip
-		cp -R ./Visual\ Studio\ Code.app /Application
-		if [ -d "/Applications/Visual Studio Code.app" ]; then
-			printf "\t$MARK_CHECK Microsoft Visual Studio Code was installed\n"
-		else
-			printf "\t$MARK_CROSS Failed to install Microsoft Visual Studio Code\n"
-		fi
-	fi
-fi
-
-printf "$MARK_CHECK SplashKit installation process has been completed.\n"
+echo -e "$MARK_CHECK SplashKit installation process has been completed."
 echo "Type \"skm help\" to get started."

--- a/install-scripts/mac/skm-install-mac.sh
+++ b/install-scripts/mac/skm-install-mac.sh
@@ -9,77 +9,77 @@ HOME_PATH=~
 INSTALL_PATH="${HOME_PATH}/.splashkit"
 
 function has_git() {
-	git --help 2>&1 > /dev/null
-	return $?
+    git --help 2>&1 > /dev/null
+    return $?
 }
 
 function install_developer_tools() {
-	echo "macOS developer tools are currently not installed which are required for installation skm."
-	read -p "Would you like to install them now? " -n 1 -r < /dev/tty
-	echo ""
-	if [[ $REPLY =~ [Yy]$ ]]
-	then
-		xcode-select --install
-	else
-		echo "macOS developer tools not installed, please run: \"xcode-select --install\" in the terminal and then reinstall."
-		exit 1
-	fi
+    echo "macOS developer tools are currently not installed which are required for installation skm."
+    read -p "Would you like to install them now? " -n 1 -r < /dev/tty
+    echo ""
+    if [[ $REPLY =~ [Yy]$ ]]
+    then
+        xcode-select --install
+    else
+        echo "macOS developer tools not installed, please run: \"xcode-select --install\" in the terminal and then reinstall."
+        exit 1
+    fi
 }
 
 echo "Checking for macOS developer tools..."
 if has_git; then
-	echo -e "\t$MARK_CHECK macOS developer tools appears to be installed"
+    echo -e "\t$MARK_CHECK macOS developer tools appears to be installed"
 else
-	install_developer_tools
-	has_git
-	if [ $? -ne 0 ]; then
-		echo -e "\t$MARK_CROSS Failed to install macOS developer tools. Please ensure you have \"git\" installed and try again."
-		exit 1
-	fi
+    install_developer_tools
+    has_git
+    if [ $? -ne 0 ]; then
+        echo -e "\t$MARK_CROSS Failed to install macOS developer tools. Please ensure you have \"git\" installed and try again."
+        exit 1
+    fi
 fi
 
 echo "Checking for an existing version of SplashKit..."
 if [ -d "${INSTALL_PATH}" ]; then
-	echo -e "\t$MARK_CROSS SplashKit is already installed!"
-	read -p "Would you like to completely re-install SplashKit? " -n 1 -r < /dev/tty
-	echo ""
-	if [[ $REPLY =~ [Yy]$ ]]; then
-		D=`date +%y%m%d-%H%M%S`
-		OLD_PATH="$INSTALL_PATH-$D"
-		echo "Removing existing SplashKit installation..."
-		mv $INSTALL_PATH $OLD_PATH
-		if [ -d "${INSTALL_PATH}" ]; then
-			echo -e "\t$MARK_CROSS failed to remove existing SplashKit installation."
-			exit 1
-		else
-			echo -e "\t$MARK_CHECK removed existing SplashKit installation."
-		fi
-	else
-		echo -e "\t$MARK_CHECK SplashKit is already installed."
-		exit 1
-	fi
+    echo -e "\t$MARK_CROSS SplashKit is already installed!"
+    read -p "Would you like to completely re-install SplashKit? " -n 1 -r < /dev/tty
+    echo ""
+    if [[ $REPLY =~ [Yy]$ ]]; then
+        D=`date +%y%m%d-%H%M%S`
+        OLD_PATH="$INSTALL_PATH-$D"
+        echo "Removing existing SplashKit installation..."
+        mv $INSTALL_PATH $OLD_PATH
+        if [ -d "${INSTALL_PATH}" ]; then
+            echo -e "\t$MARK_CROSS failed to remove existing SplashKit installation."
+            exit 1
+        else
+            echo -e "\t$MARK_CHECK removed existing SplashKit installation."
+        fi
+    else
+        echo -e "\t$MARK_CHECK SplashKit is already installed."
+        exit 1
+    fi
 fi
 
 echo "Installing SplashKit..."
 git clone --depth 1 --branch master $GIT_SKM_REPO "${INSTALL_PATH}"
 if [ -d "${INSTALL_PATH}" ]; then
-	echo -e "\t$MARK_CHECK SplashKit was installed."
+    echo -e "\t$MARK_CHECK SplashKit was installed."
 else
-	echo -e "\t$MARK_CROSS failed to install SplashKit."
-	exit 1
+    echo -e "\t$MARK_CROSS failed to install SplashKit."
+    exit 1
 fi
 
 # Add to .bashrc if using bash and path line is missing for SplashKit inclusion.
 if [ ${SHELL} = "/bin/bash" ]; then
-	echo "Adding \"$INSTALL_PATH\" to your bash profile..."
-	grep -Fqx "export PATH=\"$INSTALL_PATH:\$PATH\"" ~/.bash_profile || echo "export PATH=\"$INSTALL_PATH:\$PATH\"" >> ~/.bash_profile
-	grep -Fqx "export PATH=\"$INSTALL_PATH:\$PATH\"" ~/.bashrc || echo "export PATH=\"$INSTALL_PATH:\$PATH\"" >> ~/.bashrc
+    echo "Adding \"$INSTALL_PATH\" to your bash profile..."
+    grep -Fqx "export PATH=\"$INSTALL_PATH:\$PATH\"" ~/.bash_profile || echo "export PATH=\"$INSTALL_PATH:\$PATH\"" >> ~/.bash_profile
+    grep -Fqx "export PATH=\"$INSTALL_PATH:\$PATH\"" ~/.bashrc || echo "export PATH=\"$INSTALL_PATH:\$PATH\"" >> ~/.bashrc
 fi
 
 # Add to .zshrc if using zsh and path line is missing for SplashKit inclusion.
 if [ ${SHELL} = "/bin/zsh" ]; then
-	echo "Adding \"$INSTALL_PATH\" to your ZSH profile..."
-	grep -Fqx "export PATH=\"$INSTALL_PATH:\$PATH\"" ~/.zshrc || echo "export PATH=\"$INSTALL_PATH:\$PATH\"" >> ~/.zshrc
+    echo "Adding \"$INSTALL_PATH\" to your ZSH profile..."
+    grep -Fqx "export PATH=\"$INSTALL_PATH:\$PATH\"" ~/.zshrc || echo "export PATH=\"$INSTALL_PATH:\$PATH\"" >> ~/.zshrc
 fi
 
 echo -e "\t$MARK_CHECK Done"
@@ -88,18 +88,18 @@ export PATH="$INSTALL_PATH:$PATH"
 # Verify installation and access
 SKM_PATH="${INSTALL_PATH}/skm"
 if [ -f $SKM_PATH ]; then
-	echo -e "$MARK_CHECK SplashKit installed successfully!"
+    echo -e "$MARK_CHECK SplashKit installed successfully!"
 else
-	echo -e "$MARK_CROSS SplashKit installation failed!"
+    echo -e "$MARK_CROSS SplashKit installation failed!"
 fi
 
 find "${INSTALL_PATH}" -name "*.sh" -exec chmod a+x "{}" \;
 
 if which skm > /dev/null 2>&1; then
-	echo -e "$MARK_CHECK Verified that \"skm\" can be accessed."
+    echo -e "$MARK_CHECK Verified that \"skm\" can be accessed."
 else
-	echo -e "$MARK_CROSS Failed to validate \"skm\" command."
-	exit 1
+    echo -e "$MARK_CROSS Failed to validate \"skm\" command."
+    exit 1
 fi
 
 echo -e "$MARK_CHECK SplashKit installation process has been completed."

--- a/install-scripts/skm-install.sh
+++ b/install-scripts/skm-install.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 
-# If the kernel is a version of macOS, run the mac-specified installer.
-if [[ `uname` = Darwin ]]; then
-    ./mac/skm-install-mac.sh
-    exit 0
-fi
-
 GIT_SKM_REPO=https://github.com/splashkit/skm.git
 
 HOME_PATH=~
@@ -19,7 +13,9 @@ if [[ `uname` = MINGW* ]] || [[ `uname` = MSYS* ]]; then
 fi
 
 function report_missing_git () {
-    if [[ `uname` = MINGW* ]] || [[ `uname` = MSYS* ]]; then
+    if [[ `uname` = Darwin ]]; then
+        echo "Developer tools not installed, please run: \"xcode-select --install\" in the terminal and then reinstall."
+    elif [[ `uname` = MINGW* ]] || [[ `uname` = MSYS* ]]; then
         echo "Git not found. Please run \"pacman -S git --noconfirm;\" in the terminal and then reinstall"
     elif [[ `uname` = Linux ]]; then
         echo "Please install git using your package manager For example: sudo apt install git"

--- a/install-scripts/skm-install.sh
+++ b/install-scripts/skm-install.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
+
+# If the kernel is a version of macOS, run the mac-specified installer.
+if [[ `uname` = Darwin ]]; then
+    ./mac/skm-install-mac.sh
+    exit 0
+fi
+
 GIT_SKM_REPO=https://github.com/splashkit/skm.git
 
 HOME_PATH=~
@@ -12,9 +19,7 @@ if [[ `uname` = MINGW* ]] || [[ `uname` = MSYS* ]]; then
 fi
 
 function report_missing_git () {
-    if [[ `uname` = Darwin ]]; then
-        echo "Developer tools not installed, please run: \"xcode-select --install\" in the terminal and then reinstall."
-    elif [[ `uname` = MINGW* ]] || [[ `uname` = MSYS* ]]; then
+    if [[ `uname` = MINGW* ]] || [[ `uname` = MSYS* ]]; then
         echo "Git not found. Please run \"pacman -S git --noconfirm;\" in the terminal and then reinstall"
     elif [[ `uname` = Linux ]]; then
         echo "Please install git using your package manager For example: sudo apt install git"


### PR DESCRIPTION
These changes provide an upgraded installation process for `skm` allowing for one-line installation process that handles dependency requirements (to ensure `git` is available) as well as the installation of "recommended developer tools" (as per the https://www.splashkit.io website).

Users are asked to manually confirm whether or not they would like these situations automatically installed via a y/n prompt.

The installer has built-in detection for existing versions of `splashkit` as well as `git` and Visual Studio Code.

This has been tested on macOS Big Sur 11.3.1 (ARM64).

Example usage:

![Screen Shot 2022-04-08 at 2 48 04 pm](https://user-images.githubusercontent.com/7271686/162366479-cf7d6a47-6b45-4d37-ab6f-69ba03a5ed0b.png)