### PR TITLE
feature: add raspbian to install_deps

### DIFF
--- a/linux/install/install_deps.sh
+++ b/linux/install/install_deps.sh
@@ -39,7 +39,7 @@ install_deps () {
 	  echo   pacman -S --needed base-devel cmake libpng sdl2 sdl2_mixer sdl2_gfx sdl2_image sdl2_net sdl2_ttf libmikmod
 	  sudo pacman -S --needed base-devel cmake libpng sdl2 sdl2_mixer sdl2_gfx sdl2_image sdl2_net sdl2_ttf libmikmod
 	  ;;
-    DEBIAN | UBUNTU | KALI )
+    DEBIAN | UBUNTU | KALI | RASPBIAN )
 	  echo Installing depencies with $1 method
 	  echo You are about to be prompt for your sudo password to install the dependencies using the following command:
 	  echo   apt-get install cmake libpng-dev libcurl4-openssl-dev libsdl2-dev libsdl2-mixer-dev libsdl2-gfx-dev libsdl2-image-dev libsdl2-net-dev libsdl2-ttf-dev libmikmod-dev libncurses5-dev libbz2-dev libflac-dev libvorbis-dev libwebp-dev libfreetype6-dev build-essential


### PR DESCRIPTION
# Raspbian Distribution Option

### This change enables install_deps() to correctly execute for RaspberryPi operating system - Raspbian.

## Problem

Although Raspbian is a derivative of Debian, the ID found in /etc/os-release is initialised as `ID=raspbian`, where `ID_LIKE=debian`

![image](https://user-images.githubusercontent.com/66236690/186405172-425c4e53-08d1-4737-9d37-21d717709ef0.png)

This causes DISTRO_ID to collect the correct OS name (RASPBIAN), but then falls through the case statement in install_deps(), failing the installation of required SplashKit dependencies during `skm linux install`

## Solution

Since the ID is collected correctly, adding `RASPBIAN` to the appropriate case solves this issue.