### PR TITLE
Fix/add gpio dependencies

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -43,33 +43,6 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 -fPIC")
 # MACRO DEFINITIONS #
 add_definitions(-DELPP_THREAD_SAFE)
 
-# RPI GPIO SETUP #
-include(CheckIncludeFile)
-find_path(BCM_HOST_INCLUDE_DIR bcm_host.h PATHS "/opt/vc/inlude")
-
-if(BCM_HOST_INCLUDE_DIR)
-    message("Raspberry Pi Detected.")
-	
-	
-    find_path(PIGPIO_INCLUDE_DIR NAMES pigpio.h pigpiod_if2.h HINTS /usr/include)
-    find_library(PIGPIO_LIB NAMES libpigpio.so HINTS /usr/lib)
-    find_library(PIGPIOD_IF2_LIB NAMES libpigpiod_if2.so HINTS /usr/lib)
-
-
-    include(FindPackageHandleStandardArgs)
-    find_package_handle_standard_args(pigpio DEFAULT_MSG PIGPIO_INCLUDE_DIR PIGPIO_LIB PIGPIOD_IF2_LIB)
-    
-	if(pigpio_FOUND)
-		message("Pigpio library found.")
-		include_directories(${PIGPIO_INCLUDE_DIRS})
-		add_definitions(-DRASPBERRY_PI)
-    else()
-		message("Pigpio library not found.")
-    endif()
-	
-    
-endif()
-
 #### END SETUP ####
 
 # SOURCE FILES
@@ -94,10 +67,6 @@ add_library(SplashKit SHARED ${SOURCE_FILES} ${C_SOURCE_FILES} ${OS_SOURCE_FILES
 target_link_libraries(SplashKit ${SPLASHKIT_REQUIRED_LIBS_LDFLAGS})
 if (APPLE)
     target_link_libraries(SplashKit "-framework CoreFoundation")
-endif()
-
-if(pigpio_FOUND)
-	target_link_libraries(SplashKit ${PIGPIO_LIB} ${PIGPIOD_IF2_LIB} pthread)
 endif()
 
 install(TARGETS SplashKit DESTINATION ${SK_DEPLOY_ROOT})

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -43,6 +43,33 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 -fPIC")
 # MACRO DEFINITIONS #
 add_definitions(-DELPP_THREAD_SAFE)
 
+# RPI GPIO SETUP #
+include(CheckIncludeFile)
+find_path(BCM_HOST_INCLUDE_DIR bcm_host.h PATHS "/opt/vc/inlude")
+
+if(BCM_HOST_INCLUDE_DIR)
+    message("Raspberry Pi Detected.")
+	
+	
+    find_path(PIGPIO_INCLUDE_DIR NAMES pigpio.h pigpiod_if2.h HINTS /usr/include)
+    find_library(PIGPIO_LIB NAMES libpigpio.so HINTS /usr/lib)
+    find_library(PIGPIOD_IF2_LIB NAMES libpigpiod_if2.so HINTS /usr/lib)
+
+
+    include(FindPackageHandleStandardArgs)
+    find_package_handle_standard_args(pigpio DEFAULT_MSG PIGPIO_INCLUDE_DIR PIGPIO_LIB PIGPIOD_IF2_LIB)
+    
+	if(pigpio_FOUND)
+		message("Pigpio library found.")
+		include_directories(${PIGPIO_INCLUDE_DIRS})
+		add_definitions(-DRASPBERRY_PI)
+    else()
+		message("Pigpio library not found.")
+    endif()
+	
+    
+endif()
+
 #### END SETUP ####
 
 # SOURCE FILES
@@ -67,6 +94,10 @@ add_library(SplashKit SHARED ${SOURCE_FILES} ${C_SOURCE_FILES} ${OS_SOURCE_FILES
 target_link_libraries(SplashKit ${SPLASHKIT_REQUIRED_LIBS_LDFLAGS})
 if (APPLE)
     target_link_libraries(SplashKit "-framework CoreFoundation")
+endif()
+
+if(pigpio_FOUND)
+	target_link_libraries(SplashKit ${PIGPIO_LIB} ${PIGPIOD_IF2_LIB} pthread)
 endif()
 
 install(TARGETS SplashKit DESTINATION ${SK_DEPLOY_ROOT})

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -43,6 +43,33 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 -fPIC")
 # MACRO DEFINITIONS #
 add_definitions(-DELPP_THREAD_SAFE)
 
+# RaspberryPi GPIO SETUP #
+find_path(BCM_HOST_INCLUDE_DIR bcm_host.h PATHS "/opt/vc/include")
+
+if(BCM_HOST_INCLUDE_DIR)
+    message("Raspberry Pi Detected.")
+
+
+    find_path(PIGPIO_INCLUDE_DIR NAMES pigpio.h pigpiod_if2.h HINTS /usr/include)
+    find_library(PIGPIO_LIB NAMES libpigpio.so HINTS /usr/lib)
+    find_library(PIGPIOD_IF2_LIB NAMES libpigpiod_if2.so HINTS /usr/lib)
+
+
+    include(FindPackageHandleStandardArgs)
+    find_package_handle_standard_args(pigpio DEFAULT_MSG PIGPIO_INCLUDE_DIR PIGPIO_LIB PIGPIOD_IF2_LIB)
+
+	if(pigpio_FOUND)
+		message("Pigpio library found.")
+		include_directories(${PIGPIO_INCLUDE_DIRS})
+		add_definitions(-DRASPBERRY_PI)
+    else()
+		message("Pigpio library not found.")
+    endif()
+
+
+endif()
+
+
 #### END SETUP ####
 
 # SOURCE FILES
@@ -67,6 +94,10 @@ add_library(SplashKit SHARED ${SOURCE_FILES} ${C_SOURCE_FILES} ${OS_SOURCE_FILES
 target_link_libraries(SplashKit ${SPLASHKIT_REQUIRED_LIBS_LDFLAGS})
 if (APPLE)
     target_link_libraries(SplashKit "-framework CoreFoundation")
+endif()
+
+if(pigpio_FOUND)
+	target_link_libraries(SplashKit ${PIGPIO_LIB} ${PIGPIOD_IF2_LIB} pthread)
 endif()
 
 install(TARGETS SplashKit DESTINATION ${SK_DEPLOY_ROOT})


### PR DESCRIPTION
## Description
Changed CMakeLists.txt to find pigpio library using `find_path()` and `find_library()` and link it along with pthread to SplashKit during compilation. If pigpio is found then we will assume we're on an Raspberry Pi and add this definition.

NOTE: Code comes from the projects CMakeLists, here: [https://github.com/thoth-tech/splashkit-core/blob/develop/projects/cmake/CMakeLists.txt](https://github.com/thoth-tech/splashkit-core/blob/develop/projects/cmake/CMakeLists.txt) and also from this utility in the pigpio repository: [https://github.com/joan2937/pigpio/blob/master/util/Findpigpio.cmake](https://github.com/joan2937/pigpio/blob/master/util/Findpigpio.cmake)

NOTE2: I've removed the pigpiod_if.so library as it is deprecated, see here: [https://abyz.me.uk/rpi/pigpio/misc.html](https://abyz.me.uk/rpi/pigpio/misc.html)

NOTE3: Currently this checks for the existence of a BCM_host.h file to see if we're on a Raspberry Pi, however I will note that pigpio does not currently support the Raspberry Pi 5 (see here: [https://github.com/joan2937/pigpio/issues/586](https://github.com/joan2937/pigpio/issues/586)) and I believe this will pass if run on a 5. Should we identify the hardware in a different way? We could potentially query /proc/cpuinfo in a script and set an environment variable?


## Type of change
Please delete options that are not relevant.

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  This change requires a documentation update

## How Has This Been Tested?
SplashKit uninstalled through skm and then installed with new CMakeLists.txt file, then `sktest` was run and this behaved as expected. Next, I successfully created a simple LED blinking program using the GPIO functions in SplashKit.

## Checklist
- [x]  My code follows the style guidelines of this project
- [x]  I have performed a self-review of my own code
- [x]  I have commented my code in hard-to-understand areas
- [x]  I have made corresponding changes to the documentation
- [x]  My changes generate no new warnings
- [x]  I have requested a review from Aditya Parmar on the Pull Request